### PR TITLE
Add go boilerplate using only std lib

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,13 @@
+# Install
+
+Install go, add bin dirs to PATH, and set GOPATH ([docs](https://golang.org/doc/install)).
+
+Clone repository and copy go directory under your go src directory.
+
+# Run
+
+The server can be started using `APP_ADDR="8080" go run main.go`.
+
+# Test
+
+The tests can be ran using `go test`

--- a/go/main.go
+++ b/go/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	addr := ":80"
+	if appAddr := os.Getenv("APP_ADDR"); appAddr != "" {
+		addr = appAddr
+	}
+
+	log.Println("listening on", addr)
+	if err := http.ListenAndServe(addr, handler()); err != nil {
+		log.Fatalln("listen and serve error:", err)
+	}
+}
+
+func handler() http.Handler {
+	http.HandleFunc("/hello", hello)
+	return http.DefaultServeMux
+}
+
+func hello(w http.ResponseWriter, r *http.Request) {
+	body, err := json.Marshal(map[string]string{"hello": "world"})
+	if err != nil {
+		log.Println("handler hello can't marshal json:", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("content-type", "application/json")
+	w.Write(body)
+}

--- a/go/main_test.go
+++ b/go/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestRouteHello(t *testing.T) {
+	srv := httptest.NewServer(handler())
+	defer srv.Close()
+
+	base, _ := url.Parse(srv.URL)
+	path, _ := url.Parse("/hello")
+	res, err := http.Get(base.ResolveReference(path).String())
+	if err != nil {
+		t.Fatal("could not send GET request:", err)
+	}
+
+	expectedStatus := http.StatusOK
+	if res.StatusCode != expectedStatus {
+		t.Errorf("expected status: %d, got: %s", expectedStatus, res.Status)
+	}
+
+	expectedType := "application/json"
+	if res.Header.Get("content-type") != expectedType {
+		t.Errorf("expected content-type: %s, got: %s", expectedType, res.Header.Get("content-type"))
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal("could not read response body:", err)
+	}
+
+	expectedBody, _ := json.Marshal(map[string]string{"hello": "world"})
+	if string(body) != string(expectedBody) {
+		t.Errorf("expected body: %s, got: %s", expectedBody, body)
+	}
+}


### PR DESCRIPTION
An attempt at an idiomatic go boilerplate that only uses the std lib. It provides just enough to not be useless but would need a fair bit added to it to be useful - either through expanding or replacing components with 3rd party packages.

In the very least it should be a starting point. 